### PR TITLE
Add openssl tags.

### DIFF
--- a/crypto/BUILD
+++ b/crypto/BUILD
@@ -172,6 +172,7 @@ configure_make(
             "libcrypto.so",
         ],
     }),
+    tags = ["openssl"],
 )
 
 cc_library(
@@ -185,6 +186,7 @@ cc_library(
         "s2a_aead_constants.h",
         "s2a_aead_crypter.h",
     ],
+    tags = ["openssl"],
     deps = [
         ":openssl",
         ":s2a_aead_crypter_util",
@@ -206,6 +208,7 @@ cc_library(
         "s2a_aead_constants.h",
         "s2a_aead_crypter.h",
     ],
+    tags = ["openssl"],
     deps = [
         ":openssl",
         "@com_google_absl//absl/memory",
@@ -218,6 +221,7 @@ cc_library(
 cc_test(
     name = "aes_gcm_crypter_openssl_test",
     srcs = ["aes_gcm_crypter_test.cc"],
+    tags = ["openssl"],
     deps = [
         ":aes_gcm_crypter_openssl",
         ":s2a_aead_crypter_test_util",
@@ -229,6 +233,7 @@ cc_test(
 cc_test(
     name = "chacha_poly_crypter_openssl_test",
     srcs = ["chacha_poly_crypter_test.cc"],
+    tags = ["openssl"],
     deps = [
         ":chacha_poly_crypter_openssl",
         ":s2a_aead_crypter_test_util",

--- a/tools/internal_ci/run_tests.bat
+++ b/tools/internal_ci/run_tests.bat
@@ -1,6 +1,9 @@
 choco install bazel -y --version 4.0.0 --limit-output
 cd github/s2a-core
 set PATH=C:\tools\msys64\usr\bin;C:\Python27;%PATH%
-bazel test --test_output=errors //...
+
+:: The OpenSSL library used in OpenSSL-specific tests is only configured to run
+:: on Linux, so omit targets with the "openssl" tag.
+bazel test --test_output=errors --test_tag_filters=-openssl --build_tag_filters=-openssl //...
 set BAZEL_EXITCODE=%errorlevel%
 exit /b %BAZEL_EXITCODE%


### PR DESCRIPTION
Any test with the "openssl" tag will not be run on Windows or MacOS CI, because the OpenSSL library that we use here is configured for Linux only.