### PR TITLE
Change S2AOptions APIs to use "S2A address".

### DIFF
--- a/handshaker/s2a_proxy.cc
+++ b/handshaker/s2a_proxy.cc
@@ -789,7 +789,7 @@ S2AProxy::CreateFrameProtector() {
     return Status(StatusCode::kFailedPrecondition,
                   "Handshake is not finished.");
   }
-  std::string s2a_address = options_->handshaker_service_url();
+  std::string s2a_address = options_->s2a_address();
   S2AFrameProtectorOptions options = {result_->tls_version,
                                       result_->ciphersuite,
                                       result_->in_traffic_secret,

--- a/handshaker/s2a_proxy_test.cc
+++ b/handshaker/s2a_proxy_test.cc
@@ -80,7 +80,7 @@ std::unique_ptr<S2AOptions> CreateTestOptions(
     bool is_client, bool unsupported_ciphersuite,
     bool client_multiple_local_identities, bool with_local_identities) {
   auto options = absl::make_unique<S2AOptions>();
-  options->set_handshaker_service_url(kHandshakerServiceAddress);
+  options->set_s2a_address(kHandshakerServiceAddress);
   options->add_supported_ciphersuite(Ciphersuite::AES_128_GCM_SHA256);
   options->add_supported_ciphersuite(Ciphersuite::AES_256_GCM_SHA384);
   options->add_supported_ciphersuite(Ciphersuite::CHACHA20_POLY1305_SHA256);

--- a/handshaker/s2a_proxy_test_util.cc
+++ b/handshaker/s2a_proxy_test_util.cc
@@ -54,7 +54,7 @@ void NoOpLogger(const std::string& message) {}
 
 std::unique_ptr<S2AOptions> CreateTestOptions() {
   auto options = absl::make_unique<S2AOptions>();
-  options->set_handshaker_service_url(kHandshakerServiceAddress);
+  options->set_s2a_address(kHandshakerServiceAddress);
   options->add_supported_ciphersuite(Ciphersuite::AES_128_GCM_SHA256);
   options->add_supported_ciphersuite(Ciphersuite::AES_256_GCM_SHA384);
   options->add_supported_ciphersuite(Ciphersuite::CHACHA20_POLY1305_SHA256);

--- a/options/s2a_options.cc
+++ b/options/s2a_options.cc
@@ -69,8 +69,8 @@ TlsVersion S2AOptions::min_tls_version() const { return min_tls_version_; }
 
 TlsVersion S2AOptions::max_tls_version() const { return max_tls_version_; }
 
-const std::string S2AOptions::handshaker_service_url() const {
-  return handshaker_service_url_;
+const std::string S2AOptions::s2a_address() const {
+  return s2a_address_;
 }
 
 const std::vector<Ciphersuite>& S2AOptions::supported_ciphersuites() const {
@@ -97,8 +97,8 @@ void S2AOptions::add_supported_ciphersuite(Ciphersuite ciphersuite) {
   supported_ciphersuites_.push_back(ciphersuite);
 }
 
-void S2AOptions::set_handshaker_service_url(const std::string& url) {
-  handshaker_service_url_ = url;
+void S2AOptions::set_s2a_address(const std::string& s2a_address) {
+  s2a_address_ = s2a_address;
 }
 
 void S2AOptions::add_local_spiffe_id(const std::string& local_spiffe_id) {
@@ -129,7 +129,7 @@ std::unique_ptr<S2AOptions> S2AOptions::Copy() const {
   auto new_options = absl::make_unique<S2AOptions>();
   new_options->set_min_tls_version(min_tls_version_);
   new_options->set_max_tls_version(max_tls_version_);
-  new_options->set_handshaker_service_url(handshaker_service_url_);
+  new_options->set_s2a_address(s2a_address_);
   new_options->local_identities_ = local_identities_;
   new_options->target_identities_ = target_identities_;
   for (auto ciphersuite : supported_ciphersuites_) {

--- a/options/s2a_options.h
+++ b/options/s2a_options.h
@@ -88,7 +88,7 @@ class S2AOptions {
   // Getters for member fields.
   TlsVersion min_tls_version() const;
   TlsVersion max_tls_version() const;
-  const std::string handshaker_service_url() const;
+  const std::string s2a_address() const;
   const std::vector<Ciphersuite>& supported_ciphersuites() const;
   const absl::flat_hash_set<Identity>& local_identities() const;
   const absl::flat_hash_set<Identity>& target_identities() const;
@@ -97,8 +97,8 @@ class S2AOptions {
   void set_min_tls_version(TlsVersion min_tls_version);
   void set_max_tls_version(TlsVersion max_tls_version);
 
-  /// The setter for the |handshaker_service_url_|.
-  void set_handshaker_service_url(const std::string& url);
+  /// The setter for the |s2a_address_|.
+  void set_s2a_address(const std::string& s2a_address);
 
   // Adds |ciphersuite| to the vector |supported_ciphersuites_|; it does not
   // remove duplicates from the vector, if they exist.
@@ -134,7 +134,7 @@ class S2AOptions {
  private:
   TlsVersion min_tls_version_ = TlsVersion::TLS1_3;
   TlsVersion max_tls_version_ = TlsVersion::TLS1_3;
-  std::string handshaker_service_url_;
+  std::string s2a_address_;
   std::vector<Ciphersuite> supported_ciphersuites_;
   absl::flat_hash_set<Identity> target_identities_;
   absl::flat_hash_set<Identity> local_identities_;

--- a/options/s2a_options_test.cc
+++ b/options/s2a_options_test.cc
@@ -32,7 +32,7 @@ using Identity = S2AOptions::Identity;
 using IdentityType = S2AOptions::IdentityType;
 using TlsVersion = S2AOptions::TlsVersion;
 
-constexpr char kHandshakerServiceUrl[] = "handshaker_service_url";
+constexpr char kS2AAddress[] = "s2a_address";
 constexpr char kLocalSpiffeId[] = "local_spiffe_id";
 constexpr char kLocalHostname[] = "local_hostname";
 constexpr char kLocalUid[] = "local_uid";
@@ -98,7 +98,7 @@ TEST(S2ACredentialsOptionsTest, Create) {
   auto options = absl::make_unique<S2AOptions>();
   options->set_min_tls_version(TlsVersion::TLS1_2);
   options->set_max_tls_version(TlsVersion::TLS1_3);
-  options->set_handshaker_service_url(kHandshakerServiceUrl);
+  options->set_s2a_address(kS2AAddress);
   for (auto ciphersuite : GetCiphersuites()) {
     options->add_supported_ciphersuite(ciphersuite);
   }
@@ -111,7 +111,7 @@ TEST(S2ACredentialsOptionsTest, Create) {
 
   EXPECT_EQ(options->min_tls_version(), TlsVersion::TLS1_2);
   EXPECT_EQ(options->max_tls_version(), TlsVersion::TLS1_3);
-  EXPECT_EQ(options->handshaker_service_url(), kHandshakerServiceUrl);
+  EXPECT_EQ(options->s2a_address(), kS2AAddress);
   EXPECT_EQ(options->supported_ciphersuites(), GetCiphersuites());
   EXPECT_EQ(options->local_identities(), GetLocalIdentities());
   EXPECT_EQ(options->target_identities(), GetTargetIdentities());
@@ -121,7 +121,7 @@ TEST(S2ACredentialsOptionsTest, CreateAndCopy) {
   auto options = absl::make_unique<S2AOptions>();
   options->set_min_tls_version(TlsVersion::TLS1_2);
   options->set_max_tls_version(TlsVersion::TLS1_3);
-  options->set_handshaker_service_url(kHandshakerServiceUrl);
+  options->set_s2a_address(kS2AAddress);
   for (auto ciphersuite : GetCiphersuites()) {
     options->add_supported_ciphersuite(ciphersuite);
   }
@@ -136,7 +136,7 @@ TEST(S2ACredentialsOptionsTest, CreateAndCopy) {
 
   EXPECT_EQ(copy_options->min_tls_version(), TlsVersion::TLS1_2);
   EXPECT_EQ(copy_options->max_tls_version(), TlsVersion::TLS1_3);
-  EXPECT_EQ(copy_options->handshaker_service_url(), kHandshakerServiceUrl);
+  EXPECT_EQ(copy_options->s2a_address(), kS2AAddress);
   EXPECT_EQ(copy_options->supported_ciphersuites(), GetCiphersuites());
   EXPECT_EQ(copy_options->local_identities(), GetLocalIdentities());
   EXPECT_EQ(copy_options->target_identities(), GetTargetIdentities());


### PR DESCRIPTION
This is done so that we can have the same name used throughout all implementations.