### PR TITLE
Downgrade Bazel version in Kokoro tests on Linux and Mac.

### DIFF
--- a/tools/internal_ci/run_asan_tests.sh
+++ b/tools/internal_ci/run_asan_tests.sh
@@ -62,7 +62,7 @@ install_protoc() {
 
 main() {
   if [[ -n "${KOKORO_ROOT}" ]]; then
-    use_bazel.sh latest
+    use_bazel.sh "4.0.0"
     install_protoc
   fi
 

--- a/tools/internal_ci/run_tests.sh
+++ b/tools/internal_ci/run_tests.sh
@@ -71,7 +71,7 @@ install_protoc() {
 
 main() {
   if [[ -n "${KOKORO_ROOT}" ]]; then
-    use_bazel.sh latest
+    use_bazel.sh "4.0.0"
     install_protoc
   fi
 

--- a/tools/internal_ci/run_tsan_tests.sh
+++ b/tools/internal_ci/run_tsan_tests.sh
@@ -62,7 +62,7 @@ install_protoc() {
 
 main() {
   if [[ -n "${KOKORO_ROOT}" ]]; then
-    use_bazel.sh latest
+    use_bazel.sh "4.0.0"
     install_protoc
   fi
 


### PR DESCRIPTION
This is necessary because of Bazel's recent pre-releases. See https://github.com/bazelbuild/bazel/issues/13526 for context.