### PR TITLE
Set S2A_ACCESS_TOKEN environment variable in all single token test cases to prevent ASAN errors.

### DIFF
--- a/s2a/src/token_manager/single_token_access_token_manager_test.cc
+++ b/s2a/src/token_manager/single_token_access_token_manager_test.cc
@@ -52,6 +52,9 @@ TEST(SingleTokenAccessTokenManagerTest, GetToken) {
 }
 
 TEST(SingleTokenAccessTokenManagerTest, BuilderSuccess) {
+  char kS2AAccessTokenEnvironmentVariable[] =
+      "S2A_ACCESS_TOKEN=s2a_access_token_from_env_variable";
+  EXPECT_EQ(putenv(kS2AAccessTokenEnvironmentVariable), 0);
   absl::StatusOr<std::unique_ptr<AccessTokenManagerInterface>> manager =
       BuildAccessTokenManager();
   EXPECT_TRUE(manager.ok());


### PR DESCRIPTION
…ses to prevent ASAN errors.